### PR TITLE
Add giotto-tda to list of Python software

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ If you know of any other tools or resources, read [Contribution Guidelines](http
 
 - [Scikit-TDA](https://scikit-tda.org/) - For non-topologists.
 
+- [giotto-tda](https://giotto-ai.github.io/gtda-docs/) - A ``scikit-learn``-compatible library for end-to-end topological machine learning including Mapper, persistent homology, vectorization methods for persistence diagrams, and preprocessing components for time series, graphs, images, and point clouds ([paper](https://openreview.net/forum?id=fjQtZJOCTXf)).
+
 - [ScTDA](https://github.com/CamaraLab/scTDA) - It includes tools for the preprocessing, analysis, and exploration of single-cell RNA-seq data based on topological representations.
 
 - [TMAP](https://tmap.readthedocs.org) - Population-scale microbiome data analysis.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ If you know of any other tools or resources, read [Contribution Guidelines](http
 
 - [Scikit-TDA](https://scikit-tda.org/) - For non-topologists.
 
-- [giotto-tda](https://giotto-ai.github.io/gtda-docs/) - A ``scikit-learn``-compatible library for end-to-end topological machine learning including Mapper, persistent homology, vectorization methods for persistence diagrams, and preprocessing components for time series, graphs, images, and point clouds ([paper](https://openreview.net/forum?id=fjQtZJOCTXf)).
+- [Giotto-TDA](https://giotto-ai.github.io/gtda-docs/) - A ``scikit-learn`` - compatible library for end-to-end topological machine learning including Mapper, persistent homology, vectorization methods for persistence diagrams, and preprocessing components for time series, graphs, images, and point clouds ([paper](https://openreview.net/forum?id=fjQtZJOCTXf)).
 
 - [ScTDA](https://github.com/CamaraLab/scTDA) - It includes tools for the preprocessing, analysis, and exploration of single-cell RNA-seq data based on topological representations.
 


### PR DESCRIPTION
Hi!  I would like to add `giotto-tda` to the software list (Python section).  I have placed it next to `scikit-tda` as it shares some of the latter's goals, particularly concerning accessibility to non-experts.  Disclaimer: I am one of the authors and maintainers of this package.